### PR TITLE
add security context for nginx-app K8s-Labs

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -26,3 +26,10 @@ spec:
         env:
         - name: COMPANY_NAME
           value: "Kubernetes Laboratories"
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
Add the following securitycontext:

securityContext:

runAsNonRoot: true

allowPrivilegeEscalation: false

capabilities:

drop: ["ALL"]

seccompProfile:

type: RuntimeDefault

to improve the security of nginx-app of Kubernetes Laboratories.